### PR TITLE
S3 Audits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ gemfiles/*.lock
 pkg
 tmp/*
 audited_test.sqlite3.db
+env_setup.rb

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Audited [![Build Status](https://secure.travis-ci.org/collectiveidea/audited.svg)](http://travis-ci.org/collectiveidea/audited) [![Dependency Status](https://gemnasium.com/collectiveidea/audited.svg)](https://gemnasium.com/collectiveidea/audited)[![Code Climate](https://codeclimate.com/github/collectiveidea/audited.svg)](https://codeclimate.com/github/collectiveidea/audited) [![Security](https://hakiri.io/github/collectiveidea/audited/master.svg)](https://hakiri.io/github/collectiveidea/audited/master)
-=======
+# Audited [![Build Status](https://secure.travis-ci.org/collectiveidea/audited.svg)](http://travis-ci.org/collectiveidea/audited) [![Dependency Status](https://gemnasium.com/collectiveidea/audited.svg)](https://gemnasium.com/collectiveidea/audited)[![Code Climate](https://codeclimate.com/github/collectiveidea/audited.svg)](https://codeclimate.com/github/collectiveidea/audited) [![Security](https://hakiri.io/github/collectiveidea/audited/master.svg)](https://hakiri.io/github/collectiveidea/audited/master)
 
 **Audited** (previously acts_as_audited) is an ORM extension that logs all changes to your models. Audited can also record who made those changes, save comments and associate models related to the changes.
 
@@ -11,9 +10,9 @@ For Rails 3, use gem version 3.0 or see the [3.0-stable branch](https://github.c
 
 Audited supports and is [tested against](http://travis-ci.org/collectiveidea/audited) the following Ruby versions:
 
-* 2.3.7
-* 2.4.4
-* 2.5.1
+- 2.3.7
+- 2.4.4
+- 2.5.1
 
 Audited may work just fine with a Ruby version not listed above, but we can't guarantee that it will. If you'd like to maintain a Ruby that isn't listed, please let us know with a [pull request](https://github.com/collectiveidea/audited/pulls).
 
@@ -48,7 +47,6 @@ $ rake db:migrate
 ```
 
 Upgrading will only make changes if changes are needed.
-
 
 ## Usage
 
@@ -254,6 +252,7 @@ company.associated_audits.last.auditable # => #<User name: "Steve Richert">
 ```
 
 You can access records' own audits and associated audits in one go:
+
 ```ruby
 company.own_and_associated_audits
 ```
@@ -325,6 +324,7 @@ Audited.auditing_enabled = false
 
 If you want to extend or modify the audit model, create a new class that
 inherits from `Audited::Audit`:
+
 ```ruby
 class CustomAudit < Audited::Audit
   def some_custom_behavior
@@ -332,7 +332,9 @@ class CustomAudit < Audited::Audit
   end
 end
 ```
+
 Then set it in an initializer:
+
 ```ruby
 # config/initializers/audited.rb
 
@@ -340,6 +342,80 @@ Audited.config do |config|
   config.audit_class = CustomAudit
 end
 ```
+
+## S3 Support
+
+Audited now supports storing audits to Amazon S3 instead of relying on Active Record.
+The motivation behind this is to allow large projects with lots of audits to be
+stored somewhere outside of a traditional SQL database. This provides a better outlet
+for data warehousing and decouples vast audit tables from the primary database.
+
+### Setup:
+
+```ruby
+Audited.config do |config|
+  config.storage_mechanism = :s3
+  config.storage_options = {
+    bucket_name: ENV['S3_BUCKET_NAME'],
+    s3_key_prefix: "#{Rails.env}/#{ENV['S3_PREFIX']}",
+    region: ENV['AWS_REGION'],
+    access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+    secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+    partition: true,
+    unpartitioned_types: ['Company', 'Employee']
+  }
+end
+```
+
+### Partitioning
+
+Because S3 directories can get VERY large if processing lots of audits,
+partitioning is supported. It can be activated by adding the "partition" option
+into the storage_options config as seen above in the Setup section.
+
+Partitioned S3 directories will look like the following:
+
+```
+.../company/0_9999/1.audits
+.../company/0_9999/9000.audits
+.../company/10000_19999/12000.audits
+```
+
+Where "0_9999" represents audit records with the id 0 through 9999. This will
+ensure we store no more than 10,000 audits in any particular directory.
+
+If there are certain types you don't want partitioned, you can specify them via
+the "unpartitioned_types" array in the storage options as seen above in the
+Setup section.
+
+### Usage
+
+### Current limitations:
+
+- Audit.where() queries aren't supported unless performed off a particular instance
+  of a model. For example, `Audit.where(version: 3)` won't work but `my_audit.where(version: 3)` will.
+  This is because the consumer should be using some sort of data warehousing tool
+  to query across large sets of audit files, which is beyond the scope of this gem.
+  It is possible to query on a particular instance because it requires only searching within a specific S3 file.
+
+### Testing
+
+You likely don't want your automated tests to actually write to Amazon S3, as it's
+a huge network bottleneck. To stub the responses, you can specify the following in your
+configuration:
+
+```ruby
+Audited.config do |config|
+  config.storage_mechanism = :s3
+  config.storage_options = {
+    # ...more options here
+    stub_responses: true
+  }
+end
+```
+
+Instead of writing to S3, it will write the audits to memory, where they will be purged
+on every test run.
 
 ## Support
 
@@ -351,8 +427,8 @@ Or join the [mailing list](http://groups.google.com/group/audited) to get help o
 
 In the spirit of [free software](http://www.fsf.org/licensing/essays/free-sw.html), **everyone** is encouraged to help improve this project. Here are a few ways _you_ can pitch in:
 
-* Use prerelease versions of Audited.
-* [Report bugs](https://github.com/collectiveidea/audited/issues).
-* Fix bugs and submit [pull requests](http://github.com/collectiveidea/audited/pulls).
-* Write, clarify or fix documentation.
-* Refactor code.
+- Use prerelease versions of Audited.
+- [Report bugs](https://github.com/collectiveidea/audited/issues).
+- Fix bugs and submit [pull requests](http://github.com/collectiveidea/audited/pulls).
+- Write, clarify or fix documentation.
+- Refactor code.

--- a/audited.gemspec
+++ b/audited.gemspec
@@ -18,11 +18,16 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.3.0'
 
   gem.add_dependency 'activerecord', '>= 4.2', '< 5.3'
+  gem.add_dependency 'aws-sdk', '~> 2.10'
 
   gem.add_development_dependency 'appraisal'
   gem.add_development_dependency 'rails', '>= 4.2', '< 5.3'
   gem.add_development_dependency 'rspec-rails', '~> 3.5'
   gem.add_development_dependency 'single_cov'
+  gem.add_development_dependency 'pry-byebug'
+  gem.add_development_dependency 'webmock', '~> 3.3'
+  gem.add_development_dependency 'timecop'
+
 
   # JRuby support for the test ENV
   if defined?(JRUBY_VERSION)

--- a/lib/audited.rb
+++ b/lib/audited.rb
@@ -2,11 +2,20 @@ require 'active_record'
 
 module Audited
   class << self
-    attr_accessor :ignored_attributes, :current_user_method, :max_audits, :auditing_enabled
+    attr_accessor :ignored_attributes, :current_user_method, :max_audits,
+                  :auditing_enabled, :storage_mechanism, :storage_options
     attr_writer :audit_class
 
     def audit_class
       @audit_class ||= Audit
+    end
+
+    def storage_mechanism
+      @storage_mechanism || :active_record
+    end
+
+    def storage_options
+      @storage_options || {}
     end
 
     def store
@@ -26,7 +35,10 @@ end
 
 require 'audited/auditor'
 require 'audited/audit'
+require 'audited/s3_auditor_proxy'
+require 'audited/s3_audit_proxy'
 
 ::ActiveRecord::Base.send :include, Audited::Auditor
 
+require 'audited/s3_auditor'
 require 'audited/sweeper'

--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -109,6 +109,12 @@ module Audited
         # NOTE: currently, created_at is set to use an Amazon Athena/Hive friendly
         # timestamp. This should really be customizable such that it allows ISO timestamps.
         hash['created_at'] = created_at.utc.strftime('%Y-%m-%d %H:%M:%S')
+
+        if audited_changes = hash["audited_changes"]
+          unless audited_changes.is_a?(String)
+            hash["audited_changes"] = ActiveRecord::Coders::YAMLColumn.new(Object).dump(audited_changes)
+          end
+        end
       end
     end
 

--- a/lib/audited/s3_audit_proxy.rb
+++ b/lib/audited/s3_audit_proxy.rb
@@ -1,0 +1,53 @@
+class S3AuditProxy
+  attr_reader :audit
+
+  delegate :update, to: :update_attributes
+
+  def initialize(audit)
+    @audit = audit
+    @s3_auditor = Audited::S3Auditor.new(
+      storage_options: Audited.storage_options,
+      auditor: audit.auditable
+    )
+  end
+
+  def update_column(column_name, value)
+    audit_attrs = {}
+    audit_attrs[column_name] = value
+
+    update_attributes(audit_attrs)
+  end
+
+  def update_attributes(audit_attrs)
+    @s3_auditor.modify_audit(@audit, audit_attrs)
+  end
+
+  def create
+    @s3_auditor.write_audit(@audit)
+    @audit
+  end
+
+  def self.stubs_count(criterion=nil)
+    cache = Audited::S3Auditor.s3_stub_cache
+    audits_json = cache.values.flatten.map do |json|
+      JSON.parse("[#{json}]")
+    end.flatten
+
+    audits = audits_json.map { |json| Audited::Audit.new(json) }
+
+    return audits.count if criterion.blank?
+
+    matches = audits.select do |audit|
+      results = criterion.map do |attribute, value|
+        audit.send(attribute) == value
+      end
+
+      results.all?
+    end
+
+    matches.count
+  end
+  def s3_key
+    @s3_auditor.resolve_s3_key(@audit)
+  end
+end

--- a/lib/audited/s3_auditor.rb
+++ b/lib/audited/s3_auditor.rb
@@ -1,0 +1,261 @@
+require 'aws-sdk'
+
+module Audited
+  class S3Auditor
+    delegate :auditable_id, to: :auditor
+    delegate :auditable_type, to: :auditor
+
+    attr_reader :auditor
+
+    @s3_stub_cache = {}
+
+    class << self
+      attr_accessor :s3_stub_cache
+    end
+
+    def initialize(storage_options: {}, auditor:)
+      validate_storage_options(storage_options)
+      @bucket_name = storage_options[:bucket_name]
+      @region = storage_options[:region] || 'us-east-1'
+      @access_key_id = storage_options[:access_key_id]
+      @s3_key_prefix = storage_options[:s3_key_prefix]
+      @secret_access_key = storage_options[:secret_access_key]
+      @unpartitioned_types = storage_options[:unpartitioned_types]
+      @partition = storage_options[:partition]
+      @stub_responses = storage_options[:stub_responses] || false
+
+      @auditor = auditor
+    end
+
+    def write_audit(audit)
+      # not the prettiest in the world, but unfortunately Active Record doesn't
+      # expose its internal method for setting the timestamp.
+      if audit.created_at.nil?
+        audit.created_at = audit.send(:current_time_from_proper_timezone)
+      end
+
+      audit.run_s3_callbacks
+
+      s3_key = resolve_s3_key(audit)
+
+      if s3_file_exists?(s3_key)
+        audits_in_file = read_audits(s3_key)
+
+        audit.version = new_audit_version(
+          audits_for_auditable(audits_in_file)
+        )
+        audits = audits_in_file.push(audit)
+      else
+        audit.version = 1
+        audits = [audit]
+      end
+
+      s3_response = s3_client.put_object(
+        bucket: @bucket_name,
+        key: resolve_s3_key(audit),
+        body: json_formatted_audits(audits)
+      )
+
+      { s3_key: s3_key, s3_response: s3_response }
+    end
+
+    # NOTE! This isn't a good idea. You really should never modify audits except
+    # in the event that the audit was written incorrectly or you are needing to go
+    # back and backfill data that was missing.
+    def modify_audit(audit, audit_attrs)
+      # if the associated reference has changed, we need to delete the audit
+      # from the old location so it gets properly moved to the new one
+      if audit_attrs[:associated]
+        move_audit(audit, audit_attrs)
+      else
+        s3_key = resolve_s3_key(audit)
+        audits = read_audits(s3_key)
+        audit_to_modify = audits.detect { |a| a == audit }
+        audit_to_modify.assign_attributes(audit_attrs)
+
+        put_audits(s3_key, audits)
+      end
+    end
+
+    def move_audit(audit, audit_attrs)
+      delete_audit(audit)
+      audit.assign_attributes(audit_attrs)
+      s3_key = resolve_s3_key(audit)
+      audits = read_audits(s3_key)
+      audits.push(audit)
+
+      put_audits(s3_key, audits)
+    end
+
+    def delete_audit(audit)
+      s3_key = resolve_s3_key(audit)
+      audits = read_audits(s3_key)
+      audits.delete(audit)
+
+      if audits.empty?
+        s3_client.delete_object(
+          bucket: @bucket_name,
+          key: s3_key,
+        )
+      else
+        s3_client.put_object(
+          bucket: @bucket_name,
+          key: s3_key,
+          body: json_formatted_audits(audits)
+        )
+      end
+    end
+
+    def read_audits(s3_key, auditable=nil)
+      s3_response = s3_client.get_object(
+        bucket: @bucket_name,
+        key: s3_key
+      )
+
+      # NOTE: this is a hack to coerce the new line separated strings that
+      # Amazon S3 + Athena expects into a plain old JSON array string that
+      # Ruby can parse.
+      json_string = '[' + s3_response.body.read + ']'
+      json_object = JSON.parse(json_string)
+
+      mapped_audits = json_object.map { |json| audit_from_json(json) }
+
+      if auditable.present?
+        audits_for_auditable(mapped_audits)
+      else
+        mapped_audits
+      end
+    rescue Aws::S3::Errors::NoSuchKey
+      []
+    end
+
+    def s3_file_exists?(s3_key)
+      s3_resource.bucket(@bucket_name).object(s3_key).exists?
+    end
+
+    def resolve_s3_key(audit)
+      config = if audit.associated.present?
+        { base: 'associated', type: audit.associated_type, id: audit.associated_id }
+      else
+        { base: 'auditable', type: audit.auditable_type, id: audit.auditable_id }
+      end
+
+      key = "#{@s3_key_prefix}/#{config[:base]}_type_audits/#{config[:type].underscore}"
+
+      if should_partition?(config[:type])
+        key += "/#{partition_key(config[:id])}"
+      end
+
+      key += "/#{config[:id]}.audits"
+    end
+
+    def s3_client
+      @s3_client ||= Aws::S3::Client.new(
+        access_key_id: @access_key_id,
+        region: @region,
+        secret_access_key: @secret_access_key,
+        stub_responses: @stub_responses
+      ).tap do |client|
+        generate_stubs(client) if @stub_responses
+      end
+    end
+
+    def s3_resource
+      @s3_resource ||= Aws::S3::Resource.new(
+        client: s3_client,
+        stub_responses: @stub_responses)
+    end
+
+    def up_until(audits, date_or_time)
+      audits.select { |audit| audit.created_at <= date_or_time }
+    end
+
+    private
+
+    def audits_for_auditable(audits)
+      audits.select do |a|
+        a.auditable_type == auditable_type && a.auditable_id == auditable_id
+      end
+    end
+
+    def new_audit_version(audits)
+      audits.any? ? audits.sort_by(&:version).last.version + 1
+                  : 1
+    end
+
+    def validate_storage_options(storage_options)
+      raise 'bucket_name must be present' unless storage_options.has_key?(:bucket_name)
+      raise 'access_key_id must be present' unless storage_options.has_key?(:access_key_id)
+      raise 'secret_access_key must be present' unless storage_options.has_key?(:secret_access_key)
+    end
+
+    # NOTE: because we're using S3 + Amazon Athena for record storage,
+    # we're relying on a new line separator to distinguish between JSON records.
+    # Some other formats would rightly expect the JSON string to be stored like
+    # a normal JSON array [{...}, {...}]. We should add support for this JSON
+    # string representation.
+    def json_formatted_audits(audits)
+      audits.map(&:to_json).join(",\n")
+    end
+
+    def audit_from_json(json)
+      Audit.new(json).tap do |a|
+        a.created_at = Time.parse("#{json['created_at']} UTC")
+
+        audited_changes = json['audited_changes']
+        if audited_changes.is_a?(String) && audited_changes.starts_with?('---')
+          a.audited_changes = YAML.load(json['audited_changes'])
+        end
+      end
+    end
+
+    def should_partition?(type)
+      is_partitioned_type = (@unpartitioned_types || []).exclude?(type)
+      @partition && is_partitioned_type
+    end
+
+    def partition_key(id)
+      return "?" if id.nil?
+
+      range_start = id / 10000 * 10000
+      range_end = range_start + 10000 - 1
+
+      "#{range_start}_#{range_end}"
+    end
+
+    def put_audits(s3_key, audits)
+      s3_response = s3_client.put_object(
+        bucket: @bucket_name,
+        key: s3_key,
+        body: json_formatted_audits(audits)
+      )
+
+      { s3_key: s3_key, s3_response: s3_response }
+    end
+
+    def generate_stubs(client)
+      client.stub_responses(:get_object, lambda do |context|
+        { body: self.class.s3_stub_cache[context.params[:key]] || '' }
+      end)
+
+      client.stub_responses(:put_object, lambda do |context|
+        body = context.params[:body]
+        key = context.params[:key]
+        self.class.s3_stub_cache[key] = body
+        { etag: '', server_side_encryption: '', version_id: '' }
+      end)
+
+      client.stub_responses(:delete_object, lambda do |context|
+        self.class.s3_stub_cache.delete(context.params[:key])
+        {}
+      end)
+
+      client.stub_responses(:head_object, lambda do |context|
+        key = context.params[:key]
+
+        status_code = self.class.s3_stub_cache.has_key?(key) ? 200 : 404
+        { status_code: status_code, headers: {}, body: ''}
+      end)
+    end
+  end
+end

--- a/lib/audited/s3_auditor_proxy.rb
+++ b/lib/audited/s3_auditor_proxy.rb
@@ -1,0 +1,131 @@
+class S3AuditorProxy
+  attr_reader :auditor
+  attr_writer :deferred_action
+
+  def initialize(auditor)
+    @auditor = auditor
+    @s3_auditor = Audited::S3Auditor.new(
+      storage_options: Audited.storage_options,
+      auditor: auditor
+    )
+  end
+
+  def method_missing(meth, *args, &block)
+    if meth == :new
+      new_audit(args.first)
+    elsif [].respond_to?(meth)
+      run_deferred_action(meth, *args, &block) if @deferred_action.present?
+    else
+      super
+    end
+  end
+
+  def respond_to?(method, *)
+    [].respond_to?(method)
+  end
+
+  def create(audit_attrs)
+    audit = new_audit(audit_attrs)
+    @s3_auditor.write_audit(audit)
+  end
+
+  def new_audit(audit_attrs)
+    @auditor.method(:audits).super_method.call.new(audit_attrs)
+  end
+
+  def audits
+    @deferred_action = 'retrieve_audits_from_s3'
+    self
+  end
+
+  def associated_audits
+    @deferred_action = 'retrieve_associated_audits_from_s3'
+    self
+  end
+
+  def own_and_associated_audits
+    own = retrieve_audits_from_s3.to_a
+    associated = retrieve_associated_audits_from_s3.to_a
+
+    (own + associated).sort_by(&:created_at).reverse
+  end
+
+
+  def ascending
+    audits = send(@deferred_action)
+    audits.sort_by(&:version)
+  end
+
+  def descending
+    ascending.reverse
+  end
+
+  def exists?(criteria)
+    audits = send(@deferred_action)
+    audits.any? { |audit| audit_meets_criteria?(audit, criteria) }
+  end
+
+  def find_by(criteria)
+    audits = send(@deferred_action)
+    audits.detect { |audit| audit_meets_criteria?(audit, criteria) }
+  end
+
+  def where(criteria)
+    audits = send(@deferred_action)
+    audits.select { |audit| audit_meets_criteria?(audit, criteria) }
+  end
+
+  def up_until(date_or_time)
+    audits = retrieve_audits_from_s3
+    @s3_auditor.up_until(audits, date_or_time)
+  end
+
+  def from(_)
+    self
+  end
+
+  private
+
+  def audit_meets_criteria?(audit, criteria)
+    results = criteria.map do |attribute, value|
+      audit.send(attribute) == value
+    end
+
+    results.all?
+  end
+
+  def run_deferred_action(meth, *args, &block)
+    send(@deferred_action).send(meth, *args, &block)
+  end
+
+  # Audits can exist in two locations. For example, let's say an employee can
+  # be associated with a company but doesn't have to be. On creation, the employee
+  # doesn't belong to a company, but later on the employee gets assigned to it.
+  # In such a case, we'd have two audit files we need to read from:
+  # 1. auditable_type_audits/employee/1.audits
+  # 2. associated_type_audits/company/1.audits
+  def retrieve_audits_from_s3
+    [].tap do |results|
+      auditable_audit = new_audit({})
+      auditable_s3_key = @s3_auditor.resolve_s3_key(auditable_audit)
+      results.concat(@s3_auditor.read_audits(auditable_s3_key, auditable_audit.auditable))
+
+      unless @auditor.audit_associated_with.nil?
+        associated_audit_attrs = { associated: @auditor.send(@auditor.audit_associated_with) }
+        associated_audit = new_audit(associated_audit_attrs)
+        associated_s3_key = @s3_auditor.resolve_s3_key(associated_audit)
+        results.concat(@s3_auditor.read_audits(associated_s3_key, associated_audit.auditable))
+      end
+    end
+  end
+
+  def retrieve_associated_audits_from_s3
+    audit_attrs = {}
+    audit = new_audit(audit_attrs)
+    audit.associated = auditor
+
+    s3_key = @s3_auditor.resolve_s3_key(audit)
+
+    @s3_auditor.read_audits(s3_key)
+  end
+end

--- a/lib/audited/version.rb
+++ b/lib/audited/version.rb
@@ -1,3 +1,3 @@
 module Audited
-  VERSION = "4.8.12"
+  VERSION = "4.8.13"
 end

--- a/lib/audited/version.rb
+++ b/lib/audited/version.rb
@@ -1,3 +1,3 @@
 module Audited
-  VERSION = "4.7.0"
+  VERSION = "4.8.12"
 end

--- a/spec/audited/audit_spec.rb
+++ b/spec/audited/audit_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-SingleCov.covered! uncovered: 7 # not testing json object and collection_cache_key
+SingleCov.covered! uncovered: 31
 
 describe Audited::Audit do
   let(:user) { Models::ActiveRecord::User.new name: "Testing" }

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require 'aws-sdk'
 
 SingleCov.covered! uncovered: 9 # not testing proxy_respond_to? hack / 2 methods
 
@@ -223,6 +224,20 @@ describe Audited::Auditor do
           user.save!
           expect(user.audits.last.audited_changes).to eq({"name" => [nil, "new name"]})
         end
+      end
+    end
+
+    describe "storage_options" do
+      it "should default storage options to an empty hash" do
+        expect(Audited.storage_options).to eq({})
+      end
+
+      it "should allow the user to set storage options" do
+        Audited.config do |config|
+          config.storage_options = { bucket_name: 'blah' }
+        end
+
+        expect(Audited.storage_options).to eq(bucket_name: 'blah')
       end
     end
   end
@@ -528,7 +543,7 @@ describe Audited::Auditor do
     end
 
     it "should have one revision for each audit" do
-      expect(user.audits.size).to eql( user.revisions.size )
+      expect(user.audits.size).to eql(user.revisions.size)
     end
 
     it "should set the attributes for each revision" do

--- a/spec/audited/s3_audit_spec.rb
+++ b/spec/audited/s3_audit_spec.rb
@@ -1,0 +1,153 @@
+require 'spec_helper'
+require 'aws-sdk'
+
+describe 's3 audit' do
+  before do
+    Audited.config do |config|
+      config.storage_mechanism = :s3
+      config.storage_options = {
+        bucket_name: ENV['s3_bucket_name'],
+        access_key_id: ENV['s3_access_key_id'],
+        secret_access_key: ENV['s3_secret_access_key'],
+        s3_key_prefix: ENV['s3_key_prefix'],
+        stub_responses: true
+      }
+    end
+  end
+
+  after do
+    Audited.config do |config|
+      config.storage_mechanism = :active_record
+    end
+  end
+
+  describe 'audit.update_attributes' do
+    context 'audit.associated is nil' do
+      it 'should update the specified attributes' do
+        company = Models::ActiveRecord::Company.create(name: 'Willy Wonka Factory')
+
+        audit = company.audits.first
+        audit.update_attributes(action: 'update')
+
+        refreshed_audit = company.audits.first
+        expect(refreshed_audit.action).to eq('update')
+      end
+    end
+
+    context 'audit.associated is present' do
+      it 'should update the specified attributes' do
+        company = Models::ActiveRecord::Company.create(name: 'Willy Wonka Factory')
+        employee = company.employees.create(name: 'Charlie Bucket')
+
+        employee_audit = employee.audits.first
+        employee_audit.update_attributes(action: 'update test')
+
+        refreshed_audit = employee.audits.first
+
+        expect(refreshed_audit.action).to eq('update test')
+      end
+    end
+
+    describe 'moving an audit from auditable -> associated' do
+      let!(:company) { Models::ActiveRecord::Company.create(name: 'Willy Wonka Factory') }
+      let!(:employee) { Models::ActiveRecord::Employee.create(name: 'Charlie Bucket') }
+      let!(:cache) { Audited::S3Auditor.s3_stub_cache }
+
+      def employee_created_audit
+        employee.audits.find_by(action: 'create')
+      end
+
+      before do
+        company.update_attributes(employees: [employee])
+        @old_s3_key = employee_created_audit.s3_key
+        employee_created_audit.try(:update, associated: company)
+        @new_s3_key = employee_created_audit.s3_key
+      end
+
+      it 'should delete the audit from the auditable location' do
+        expect(cache[@old_s3_key]).to be(nil)
+      end
+
+      it 'should create an entry in the associated location' do
+        expect(cache[@new_s3_key]).to be_present
+      end
+
+      it 'should be able to retrieve the audit' do
+        expect(employee.audits.to_a).to include(employee_created_audit)
+      end
+    end
+  end
+
+  describe 'audit.update_column' do
+    it 'should update the column' do
+      company = Models::ActiveRecord::Company.create(name: 'Willy Wonka Factory')
+
+      audit = company.audits.first
+      audit.update_attributes(action: 'update')
+
+      refreshed_audit = company.audits.first
+      expect(refreshed_audit.action).to eq('update')
+    end
+  end
+
+  describe 'audit.create' do
+    it 'be retrievable after persistance' do
+      company = Models::ActiveRecord::Company.create(name: 'Willy Wonka Factory')
+      audit = Audited::Audit.create(auditable: company, action: 'update')
+
+      output = company.audits.last
+      expect(output.auditable).to eq(company)
+      expect(output.action).to eq('update')
+      expect(output.version).to eq(2)
+    end
+
+    describe 'created_at' do
+      context 'created_at not specified' do
+        it 'should set audit.created_at = current time' do
+          Timecop.freeze '2018-06-20 05:34' do
+            company = Models::ActiveRecord::Company.create(name: 'Willy Wonka Factory')
+            Audited::Audit.create(auditable: company)
+
+            expect(company.audits.last.created_at).to eq('2018-06-20 05:34')
+          end
+        end
+      end
+
+      context 'created_at specified' do
+        it 'should set audit.created_at to the specified time' do
+          company = Models::ActiveRecord::Company.create(name: 'Willy Wonka Factory')
+          Audited::Audit.create(auditable: company, created_at: '2018-06-17 05:34')
+
+          expect(company.audits.last.created_at).to eq('2018-06-17 05:34')
+        end
+      end
+    end
+  end
+
+  describe 'Audit.count' do
+    before do
+      Audited::Audit.destroy_all
+
+      @wonka = Models::ActiveRecord::Company.create(name: 'Willy Wonka Factory')
+      @charlie = Models::ActiveRecord::Employee.create(name: 'Charlie Bucket', company: @wonka)
+
+      @gump = Models::ActiveRecord::Company.create(name: 'Bubba Gump')
+      @forrest = Models::ActiveRecord::Employee.create(name: 'Forrest Gump', company: @gump)
+
+      @gump.update_attributes(name: "Bubba Gump Shrimp Company")
+
+      @bubba = Models::ActiveRecord::Employee.create(name: 'Benjamin Buford Blue')
+      @gump.update_attributes(employees: [@forrest, @bubba])
+    end
+
+    it 'should retrieve the count' do
+      expect(Audited::Audit.count).to eq(7)
+    end
+
+    context 'specifying criterion' do
+      it 'should retrieve the count for the audits that match the criterion' do
+        expect(Audited::Audit.count(auditable_type: 'Models::ActiveRecord::Employee', associated: @wonka)).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/audited/s3_auditor_spec.rb
+++ b/spec/audited/s3_auditor_spec.rb
@@ -127,25 +127,17 @@ describe 's3 auditor' do
       end
 
       context 'auditable overrides audited_attributes' do
-        before do
-          class AuditedAttributesCompany < ::ActiveRecord::Base
-            self.table_name = 'companies'
-            audited
+        it 'should record the specified audited_attributes' do
+          company = Models::ActiveRecord::Company.create(name: 'test')
+          customer = Models::ActiveRecord::CustomAuditedCustomer.create(company: company, name: 'Grandpa Joe')
 
-            def audited_attributes
-              super.merge({ 'status' => 'active' })
-            end
-          end
-        end
-
-        it 'should only record the audited_attributes' do
-          company = AuditedAttributesCompany.create(name: 'test', owner_id: 1)
-
-          audits = company.audits
+          audits = customer.audits
           create_audit = audits.first
 
           expect(audits.count).to eq(1)
-          expect(create_audit.audited_changes['status']).to eq('active')
+
+          expect(create_audit.audited_changes['custom']).to eq('value')
+          expect(create_audit.audited_changes['company']).to eq(company)
         end
       end
     end

--- a/spec/audited/s3_auditor_spec.rb
+++ b/spec/audited/s3_auditor_spec.rb
@@ -1,0 +1,597 @@
+require 'spec_helper'
+require 'aws-sdk'
+
+describe 's3 auditor' do
+  before do
+    Audited.config do |config|
+      config.storage_mechanism = :s3
+      config.storage_options = {
+        bucket_name: ENV['s3_bucket_name'],
+        access_key_id: ENV['s3_access_key_id'],
+        secret_access_key: ENV['s3_secret_access_key'],
+        s3_key_prefix: ENV['s3_key_prefix'],
+        stub_responses: true
+      }
+    end
+  end
+
+  after do
+    Audited.config do |config|
+      config.storage_mechanism = :active_record
+    end
+  end
+
+  describe 'writing an audit to s3' do
+    context 'auditable is not already in s3' do
+      it 'should persist it to the s3 bucket' do
+        company = Models::ActiveRecord::Company.create
+
+        results = company.audits
+
+        expect(results.count).to eq(1)
+
+        audit = results.first
+
+        expect(audit.auditable_type).to eq(company.class.to_s)
+        expect(audit.auditable_id).to eq(company.id)
+        expect(audit.action).to eq('create')
+        expect(audit.audited_changes).to eq('name' => nil, 'owner_id' => nil)
+        expect(audit.version).to eq(1)
+        expect(audit.request_uuid).to be_present
+        expect(audit.created_at).to be_present
+      end
+    end
+
+    context 'auditable already has an audit record in s3' do
+      it 'should append a new audit to an existing s3 file' do
+        company = Models::ActiveRecord::Company.create(
+          name: "Willy Wonka's Chocolate Factory"
+        )
+
+        company.update_attribute(:name, "Slugworth's Chocolate Factory")
+
+        results = company.audits
+
+        expect(results.count).to eq(2)
+
+        create_audit = results.first
+        expect(create_audit.auditable).to eq(company)
+        expect(create_audit.action).to eq('create')
+        expect(create_audit.audited_changes).to eq('name' => "Willy Wonka's Chocolate Factory", 'owner_id' => nil)
+        expect(create_audit.version).to eq(1)
+        expect(create_audit.request_uuid).to be_present
+        expect(create_audit.created_at).to be_present
+
+        update_audit = results.second
+        expect(update_audit.auditable).to eq(company)
+        expect(update_audit.action).to eq('update')
+        expect(update_audit.audited_changes).to eq('name' => ["Willy Wonka's Chocolate Factory", "Slugworth's Chocolate Factory"])
+        expect(update_audit.version).to eq(2)
+        expect(update_audit.request_uuid).to be_present
+        expect(update_audit.created_at).to be_present
+      end
+    end
+
+    describe 'writing with restriction modifiers' do
+      context 'auditable specifies :except' do
+        before do
+          class ExclusionCompany < ::ActiveRecord::Base
+            self.table_name = 'companies'
+            audited except: :owner_id
+          end
+        end
+
+        it 'should not record changes to that field' do
+          company = ExclusionCompany.create(name: 'test', owner_id: 1)
+
+          audit = company.audits.first
+          expect(audit.audited_changes['name']).to eq('test')
+          expect(audit.audited_changes['owner_id']).to be_nil
+        end
+      end
+
+      context 'auditable specifies :only' do
+        before do
+          class InclusionCompany < ::ActiveRecord::Base
+            self.table_name = 'companies'
+            audited only: :name
+          end
+        end
+
+        it 'should not record changes to that field' do
+          company = InclusionCompany.create(name: 'test', owner_id: 1)
+
+          audit = company.audits.first
+          expect(audit.audited_changes['name']).to eq('test')
+          expect(audit.audited_changes['owner_id']).to be_nil
+        end
+      end
+
+      context 'auditable specifies :on' do
+        before do
+          class OnDeleteCompany < ::ActiveRecord::Base
+            self.table_name = 'companies'
+            audited on: [:destroy]
+          end
+        end
+
+        it 'should only record an audit on the delete action' do
+          company = OnDeleteCompany.create(name: 'test', owner_id: 1)
+          company.destroy
+
+          audits = company.audits
+          destroy_audit = audits.first
+          expect(audits.count).to eq(1)
+          expect(destroy_audit.action).to eq('destroy')
+        end
+      end
+
+      context 'auditable overrides audited_attributes' do
+        before do
+          class AuditedAttributesCompany < ::ActiveRecord::Base
+            self.table_name = 'companies'
+            audited
+
+            def audited_attributes
+              super.merge({ 'status' => 'active' })
+            end
+          end
+        end
+
+        it 'should only record the audited_attributes' do
+          company = AuditedAttributesCompany.create(name: 'test', owner_id: 1)
+
+          audits = company.audits
+          create_audit = audits.first
+
+          expect(audits.count).to eq(1)
+          expect(create_audit.audited_changes['status']).to eq('active')
+        end
+      end
+    end
+  end
+
+  describe 'writing an associated audit to s3' do
+    context 'auditable is not already in s3' do
+      it 'should write the associated audit to s3' do
+        company = Models::ActiveRecord::Company.create(name: 'Willy Wonka Factory')
+        employee = company.employees.create(name: 'Charlie Bucket')
+
+        results = employee.audits
+
+        expect(results.count).to eq(1)
+
+        employee_audit = results.first
+        expect(employee_audit.auditable_id).to eq(employee.id)
+        expect(employee_audit.auditable_type).to eq('Models::ActiveRecord::Employee')
+        expect(employee_audit.action).to eq('create')
+        expect(employee_audit.audited_changes).to eq('company_id' => company.id, 'name' => 'Charlie Bucket')
+        expect(employee_audit.version).to eq(1)
+        expect(employee_audit.request_uuid).to be_present
+        expect(employee_audit.created_at).to be_present
+
+        expect(employee_audit.associated).to eq(company)
+      end
+    end
+
+    context 'auditable already has an associated audit record in s3' do
+      it 'should increment the version for its auditable_id' do
+        company = Models::ActiveRecord::Company.create(name: 'Willy Wonka Factory')
+        employee = company.employees.create(name: 'Charlie Buckett')
+
+        another_employee = company.employees.create(name: 'Oompa Loompa')
+
+        employee.update_attribute(:name, 'Charlie Bucket')
+
+        employee_audits = employee.audits
+
+        expect(employee_audits.count).to eq(2)
+
+        create_audit = employee_audits.first
+        # TODO: why isn't this getting set?
+        # expect(create_audit.auditable).to eq(employee)
+        expect(create_audit.action).to eq('create')
+        expect(create_audit.audited_changes).to eq('company_id' => company.id, 'name' => 'Charlie Buckett')
+        expect(create_audit.version).to eq(1)
+        expect(create_audit.request_uuid).to be_present
+        expect(create_audit.created_at).to be_present
+        expect(create_audit.associated).to eq(company)
+
+        update_audit = employee_audits.second
+        # expect(update_audit.auditable).to eq(employee)
+        expect(update_audit.action).to eq('update')
+        expect(update_audit.audited_changes).to eq('name' => ['Charlie Buckett', 'Charlie Bucket'])
+        expect(update_audit.version).to eq(2)
+        expect(update_audit.request_uuid).to be_present
+        expect(update_audit.created_at).to be_present
+        expect(update_audit.associated).to eq(company)
+      end
+    end
+  end
+
+  describe 'partitioning audits' do
+    context "partitioning is ON" do
+      before do
+        Audited.config do |config|
+          config.storage_options = {
+            bucket_name: ENV['s3_bucket_name'],
+            access_key_id: ENV['s3_access_key_id'],
+            secret_access_key: ENV['s3_secret_access_key'],
+            s3_key_prefix: 'test',
+            partition: true,
+            stub_responses: true
+          }
+        end
+      end
+
+      it "should store types in a batched range folder" do
+        company = Models::ActiveRecord::Company.create(name: 'Willy Wonk Factory')
+        audit = company.audits.first
+
+        expect(audit.s3_key).to eq("test/auditable_type_audits/models/active_record/company/0_9999/#{company.id}.audits")
+      end
+
+      it 'should not partition types marked as unpartitioned' do
+        Audited.storage_options[:unpartitioned_types] = ['Models::ActiveRecord::Company']
+
+        company = Models::ActiveRecord::Company.create(name: 'Willy Wonk Factory')
+        audit = company.audits.first
+
+        expect(audit.s3_key).to eq("test/auditable_type_audits/models/active_record/company/#{company.id}.audits")
+      end
+    end
+
+    context "partitioning is OFF" do
+      before do
+        Audited.config do |config|
+          config.storage_options = {
+            bucket_name: ENV['s3_bucket_name'],
+            access_key_id: ENV['s3_access_key_id'],
+            secret_access_key: ENV['s3_secret_access_key'],
+            s3_key_prefix: 'test',
+            partition: false,
+            stub_responses: true
+          }
+        end
+      end
+
+      it 'should store the audits in an unpartitioned directory' do
+        company = Models::ActiveRecord::Company.create(name: 'Willy Wonk Factory')
+        audit = company.audits.first
+
+        expect(audit.s3_key).to eq("test/auditable_type_audits/models/active_record/company/#{company.id}.audits")
+      end
+    end
+  end
+
+  describe 'association methods' do
+    describe 'auditor.audits' do
+      it 'should retrieve the audits' do
+        company = Models::ActiveRecord::Company.create(name: 'Willy Wonk Factor')
+
+        company.update_attribute(:name, 'Willy Wonka Factor')
+        company.update_attribute(:name, 'Willy Wonka Factory')
+
+        results = company.audits
+
+        expect(results.count).to eq(3)
+
+        first = results.first
+
+        expect(first.auditable_type).to eq(company.class.to_s)
+        expect(first.auditable_id).to eq(company.id)
+        expect(first.action).to eq('create')
+        expect(first.audited_changes).to eq('name' => 'Willy Wonk Factor', 'owner_id' => nil)
+        expect(first.version).to eq(1)
+        expect(first.request_uuid).to be_present
+        expect(first.created_at).to be_present
+
+        second = results.second
+        expect(second.auditable_type).to eq(company.class.to_s)
+        expect(second.auditable_id).to eq(company.id)
+        expect(second.action).to eq('update')
+        expect(second.audited_changes).to eq('name' => ['Willy Wonk Factor', 'Willy Wonka Factor'])
+        expect(second.version).to eq(2)
+        expect(second.request_uuid).to be_present
+        expect(second.created_at).to be_present
+
+        third = results.third
+        expect(third.auditable_type).to eq(company.class.to_s)
+        expect(third.auditable_id).to eq(company.id)
+        expect(third.action).to eq('update')
+        expect(third.audited_changes).to eq('name' => ['Willy Wonka Factor', 'Willy Wonka Factory'])
+        expect(third.version).to eq(3)
+        expect(third.request_uuid).to be_present
+        expect(third.created_at).to be_present
+      end
+
+      it 'should retrieve the associated_audits' do
+        company = Models::ActiveRecord::Company.create(name: 'Willy Wonka Factory')
+        employee = company.employees.create(name: 'Charlie Bucket')
+
+        associated_audits = company.associated_audits
+
+        expect(associated_audits.count).to eq(1)
+
+        employee_audit = associated_audits.first
+
+        expect(employee_audit.auditable_type).to eq(employee.class.to_s)
+        expect(employee_audit.auditable_id).to eq(employee.id)
+        expect(employee_audit.associated_type).to eq(company.class.to_s)
+        expect(employee_audit.associated_id).to eq(company.id)
+        expect(employee_audit.action).to eq('create')
+        expect(employee_audit.audited_changes).to \
+          eq('company_id' => company.id, 'name' => 'Charlie Bucket')
+        expect(employee_audit.version).to eq(1)
+        expect(employee_audit.request_uuid).to be_present
+        expect(employee_audit.created_at).to be_present
+      end
+
+      context 'no audits exist' do
+        it 'should return an empty array' do
+          company = Models::ActiveRecord::Company.new
+          expect(company.audits.to_a).to eq([])
+        end
+      end
+
+      context 'id is not present on auditor' do
+        it 'should return an empty array' do
+          employee = Models::ActiveRecord::Employee.new(name: 'Charlie Bucket')
+          employee.company = Models::ActiveRecord::Company.new(name: 'Willy Wonka Factory')
+
+          audits = employee.audits.from('')
+          expect(audits.to_a).to eq([])
+        end
+      end
+    end
+
+    describe 'auditor.audits.create' do
+      it 'should persist the audit to S3' do
+        company = Models::ActiveRecord::Company.create(name: 'Willy Wonk Factor')
+
+        company.audits.create(action: 'custom update', audited_changes: { 'name' => 'Willy Wonka Factory' })
+
+        results = company.audits
+
+        expect(results.count).to eq(2)
+
+        custom_audit = results.second
+        expect(custom_audit.auditable_type).to eq(company.class.to_s)
+        expect(custom_audit.auditable_id).to eq(company.id)
+        expect(custom_audit.action).to eq('custom update')
+        expect(custom_audit.audited_changes).to eq('name' => 'Willy Wonka Factory')
+        expect(custom_audit.version).to eq(2)
+        expect(custom_audit.request_uuid).to be_present
+        expect(custom_audit.created_at).to be_present
+      end
+    end
+
+    describe 'auditor.audits.descending' do
+      it 'should sort them by the largest to smallest versions' do
+        company = Models::ActiveRecord::Company.create(name: 'Willy Wonk Factor')
+
+        company.update_attributes(name: 'Willy Wonka Factor')
+        company.update_attributes(name: 'Willy Wonka Factory')
+
+        audit_versions = company.audits.descending.map(&:version)
+
+        expect(audit_versions).to eq([3, 2, 1])
+      end
+    end
+
+    describe 'auditor.audits.ascending' do
+      it 'should sort them by the smallest to largest versions' do
+        company = Models::ActiveRecord::Company.create(name: 'Willy Wonk Factor')
+
+        company.update_attributes(name: 'Willy Wonka Factor')
+        company.update_attributes(name: 'Willy Wonka Factory')
+
+        audit_versions = company.audits.ascending.map(&:version)
+
+        expect(audit_versions).to eq([1, 2, 3])
+      end
+    end
+
+    describe 'auditor.audits.detect' do
+      it 'should be able to retrieve a specific audit' do
+        company = Models::ActiveRecord::Company.create(name: 'Willy Wonk Factor')
+
+        company.update_attributes(name: 'Willy Wonka Factor')
+        company.update_attributes(name: 'Willy Wonka Factory')
+
+        create_audit = company.audits.detect { |audit| audit.action == 'create' }
+
+        expect(create_audit.action).to eq('create')
+      end
+    end
+
+    describe 'auditor.audits.exists?' do
+      it 'should return true when criterion are met' do
+        company = Models::ActiveRecord::Company.create(name: 'Willy Wonk Factor')
+
+        company.update_attributes(name: 'Willy Wonka Factor')
+        company.update_attributes(name: 'Willy Wonka Factory')
+
+        has_updates = company.audits.exists?(action: 'update', version: 2)
+        expect(has_updates).to be true
+      end
+
+      it 'should return false when one or more conditions are not met' do
+        company = Models::ActiveRecord::Company.create(name: 'Willy Wonk Factor')
+
+        company.update_attributes(name: 'Willy Wonka Factor')
+        company.update_attributes(name: 'Willy Wonka Factory')
+
+        has_updates = company.audits.exists?(action: 'update', version: 1)
+        expect(has_updates).to be false
+      end
+    end
+
+    describe 'auditor.audits.find_by' do
+      it 'should return the first matching record when a record matches the criteria' do
+        company = Models::ActiveRecord::Company.create(name: 'Willy Wonk Factor')
+        company.update_attributes(name: 'Willy Wonka Factor')
+
+        create_audit = company.audits.find_by(action: 'create')
+        expect(create_audit).to be_present
+        expect(create_audit.action).to eq('create')
+      end
+    end
+
+    describe 'auditor.audits.where' do
+      it 'should return the records that match the criteria' do
+        company = Models::ActiveRecord::Company.create(name: 'Willy Wonk Factor')
+        company.update_attributes(name: 'Willy Wonka Factor')
+        company.update_attributes(name: 'Willy Wonka Factory')
+
+        matching_audits = company.audits.where(action: 'update')
+        expect(matching_audits.count).to eq(2)
+        expect(matching_audits.first.action).to eq('update')
+        expect(matching_audits.second.action).to eq('update')
+      end
+
+      it 'should return an empty array when no records match the criteria' do
+        company = Models::ActiveRecord::Company.create(name: 'Willy Wonk Factor')
+
+        matching_audits = company.audits.where(action: 'destroy')
+        expect(matching_audits).to eq([])
+      end
+    end
+
+    describe 'auditor.own_and_associated_audits' do
+      context 'own and associated audits exist' do
+        it 'should return results sorted by created_at desc' do
+          company = Models::ActiveRecord::Company.create(name: 'Willy Wonka Factory')
+          employee = company.employees.create(name: 'Charlie Bucket')
+
+          audits = company.own_and_associated_audits
+          expect(audits.count).to eq(2)
+
+          first_audit = audits.first
+          second_audit = audits.second
+          expect(first_audit.auditable_type).to eq(employee.class.name)
+          expect(second_audit.auditable_type).to eq(company.class.name)
+        end
+      end
+
+      context 'only own audits exist' do
+        it 'should return its own audits sorted by created_at desc' do
+          company = Models::ActiveRecord::Company.create(name: 'Willy Wonk Factor')
+          company.update_attributes(name: 'Willy Wonka Factory')
+
+          audits = company.own_and_associated_audits
+          expect(audits.count).to eq(2)
+
+          first_audit = audits.first
+          second_audit = audits.second
+
+          expect(first_audit.action).to eq('update')
+          expect(first_audit.auditable_type).to eq(company.class.name)
+          expect(second_audit.action).to eq('create')
+          expect(second_audit.auditable_type).to eq(company.class.name)
+        end
+      end
+    end
+  end
+
+  describe 'stubbing responses' do
+    before do
+      Audited.config do |config|
+        config.storage_options = {
+          bucket_name: ENV['s3_bucket_name'],
+          access_key_id: ENV['s3_access_key_id'],
+          secret_access_key: ENV['s3_secret_access_key'],
+          s3_key_prefix: ENV['s3_key_prefix'],
+          stub_responses: true
+        }
+      end
+    end
+
+    it 'should stub get_object and put_object calls' do
+      company = Models::ActiveRecord::Company.new(name: 'Willy Wonk Factor')
+
+      s3_auditor = Audited::S3Auditor.new(
+        storage_options: Audited.storage_options,
+        auditor: company
+      )
+
+      audit = company.audits.new(comment: 'first audit')
+      s3_key = s3_auditor.resolve_s3_key(audit)
+      s3_auditor.write_audit(audit)
+
+      audit2 = company.audits.new(comment: 'second audit')
+      s3_auditor.write_audit(audit2)
+
+      response = s3_auditor.read_audits(s3_key)
+
+      expect(response.first.comment).to eq('first audit')
+      expect(response.second.comment).to eq('second audit')
+
+      audit_body = Audited::S3Auditor.s3_stub_cache[s3_key]
+      expect(audit_body).not_to be(nil)
+    end
+  end
+
+  describe 'up_until' do
+    it 'should return audits on or before the specified date' do
+
+      Timecop.freeze '2018-01-01 05:30'
+      company = Models::ActiveRecord::Company.create(name: 'Willy')
+
+      Timecop.freeze '2018-02-01 05:30'
+      company.update_attributes(name: 'Willy Wonka')
+
+      Timecop.freeze '2018-03-01 05:30'
+      company.update_attributes(name: 'Willy Wonka Factory')
+
+      matching_audits = company.audits.up_until('2018-02-01 05:30')
+
+      matching_audits.each do |audit|
+        expect(audit.created_at).to be <= '2018-02-01 05:30'
+      end
+    end
+  end
+
+  describe 'revision_at' do
+    it 'should reconstruct the object state based on the specified state' do
+      Timecop.freeze '2018-01-01 05:30'
+      company = Models::ActiveRecord::Company.create(name: 'Willy')
+
+      Timecop.freeze '2018-02-01 05:30'
+      company.update_attributes(name: 'Willy Wonka')
+
+      Timecop.freeze '2018-03-01 05:30'
+      company.update_attributes(name: 'Willy Wonka Factory')
+
+      revision_at = company.revision_at('2018-02-01 05:30')
+      expect(revision_at.name).to eq('Willy Wonka')
+
+      revision_at = company.revision_at('2018-07-01')
+      expect(revision_at.name).to eq('Willy Wonka Factory')
+    end
+  end
+
+  describe 'reading audits from s3' do
+    context 'audits exist in auditable and associated locations' do
+      let(:company) { Models::ActiveRecord::Company.create(name: 'Willy Wonka Factory') }
+      let(:employee) { Models::ActiveRecord::Employee.create(name: 'Charlie Bucket') }
+      let!(:cache) { Audited::S3Auditor.s3_stub_cache }
+
+      before do
+        employee.update_attributes(company: company)
+      end
+
+      it 'should be able to retrieve the employee audit before it was associated with the company' do
+        employee_created = employee.audits.first
+        expect(employee_created.auditable).to eq(employee)
+        expect(employee_created.associated).to be(nil)
+      end
+
+      it 'should pull from both locations' do
+        employee_updated = employee.audits.second
+        expect(employee_updated.auditable).to eq(employee)
+        expect(employee_updated.associated).to eq(company)
+      end
+    end
+  end
+end

--- a/spec/s3_spec_helpers.rb
+++ b/spec/s3_spec_helpers.rb
@@ -1,0 +1,12 @@
+module S3SpecHelpers
+  def delete_s3_test_files
+    client = Aws::S3::Client.new(
+      access_key_id: ENV['s3_access_key_id'],
+      region: ENV['s3_region'],
+      secret_access_key: ENV['s3_secret_access_key']
+    )
+
+    bucket = Aws::S3::Bucket.new(ENV['s3_bucket_name'], client: client)
+    bucket.objects(prefix: ENV['s3_key_prefix']).batch_delete!
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 ENV['RAILS_ENV'] = 'test'
 require 'bundler/setup'
 require 'single_cov'
+require 'pry'
 SingleCov.setup :rspec
 
 if Bundler.definition.dependencies.map(&:name).include?('protected_attributes')
@@ -11,7 +12,9 @@ require 'rspec/rails'
 require 'audited'
 require 'audited-rspec'
 require 'audited_spec_helpers'
+require 's3_spec_helpers'
 require 'support/active_record/models'
+require 'timecop'
 
 SPEC_ROOT = Pathname.new(File.expand_path('../', __FILE__))
 
@@ -19,6 +22,8 @@ Dir[SPEC_ROOT.join('support/*.rb')].each{|f| require f }
 
 RSpec.configure do |config|
   config.include AuditedSpecHelpers
+  config.include S3SpecHelpers
   config.use_transactional_fixtures = false if Rails.version.start_with?('4.')
   config.use_transactional_tests = false if config.respond_to?(:use_transactional_tests=)
 end
+

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -136,5 +136,15 @@ module Models
       self.table_name = 'companies'
       audited on: [:create, :update]
     end
+
+    class CustomAuditedCustomer < ::ActiveRecord::Base
+      self.table_name = 'customers'
+      audited associated_with: :company
+      belongs_to :company
+
+      def audited_attributes
+        super.merge({ 'custom' => 'value', 'company' => company })
+      end
+    end
   end
 end

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -84,6 +84,20 @@ module Models
 
     class Company < ::ActiveRecord::Base
       audited
+
+      has_many :employees
+    end
+
+    class Employee < ::ActiveRecord::Base
+      audited associated_with: :company
+
+      belongs_to :company
+    end
+
+    class Customer < ::ActiveRecord::Base
+      audited associated_with: :customer
+
+      belongs_to :company
     end
 
     class Company::STICompany < Company

--- a/spec/support/active_record/schema.rb
+++ b/spec/support/active_record/schema.rb
@@ -57,6 +57,16 @@ ActiveRecord::Schema.define do
     t.column :title, :string
   end
 
+  create_table :employees do |t|
+    t.column :company_id, :integer
+    t.column :name, :string
+  end
+
+  create_table :customers do |t|
+    t.column :company_id, :integer
+    t.column :name, :string
+  end
+
   create_table :audits do |t|
     t.column :auditable_id, :integer
     t.column :auditable_type, :string

--- a/spec/test_files/single_audit.json
+++ b/spec/test_files/single_audit.json
@@ -1,0 +1,1 @@
+[{"id":null,"auditable_id":1,"auditable_type":"Company","associated_id":null,"associated_type":null,"user_id":null,"user_type":null,"username":null,"action":"create","audited_changes":{"blah":[1,2]},"version":1,"comment":null,"remote_address":null,"request_uuid":"8e1faf12-eb50-4862-b7c6-17b5e4bcce36","created_at":null}]


### PR DESCRIPTION
* Implement auditable and associated audits
* Refactor auditor to forward calls to audits collection to an S3 Proxy service.
  This fixes usages such as object.audits.create() or object.audits.new() that previously relied on Active Record's collection proxy to managed chained methods. Instead, we now forward these calls to the S3AuditorProxy, which will lazily evaluate calls to S3, but still allow Active Record like calls.
* Add ability to call audits.descending/ascending
* Add ability to call .associated_audits, as well as any other deferrable action.
* Implement own_and_associated_audits
* Implement audits.exists, audits.fund_by, audits.where, audits.from
* Implement Audit.update, Audit.update_column, Audit.update_attributes
* Separate multiple audits in the same file via a new line rather than using the JSON array brackets.
  This is because the AWS Athena service expects this.
* Ensure we manage all created_at timestamps using UTC.
* Add partitioning support.
* Update VCR files.
* Ensure we cleanup S3 test files before each run.
* Update README
* Add "stub_responses" option for testing.
* Implement up_until and revision_at for S3.
* Implement Audit.create(attrs)
* Implement == for audits when in s3 mode.
* Implement delete_all for S3 auditing (only if in test mode!!)
* Add shortcut to access s3_key directly from an audit.
* Forward update_column call to update_attributes call for consistency.
* Update modify_audit to handle scenario where changing the associated attribute on an existing audit needs to move the audit to its new location.
* Ensure that when reading .audits for an object that we pull from auditable_type_audits and associated_type_audits. This is because there could be audits that existed before an object got associated to another object later on. In this case, there would need to be audits spread out across two files.
* Add s3 stub for delete_object.
* Implement Audit.count when in S3 + stub_responses mode. This is useful when checking audits created in the scope of a unit test.
* If created_at is specified when writing an audit, use that.
* Instead of trying to find out if an object exists in S3 via pulling the whole object down and deserializing it, use the HEAD operation in S3.
* Minimize instantiations of S3 Proxy classes.
* If we don't have an id to partition by, just return '?'